### PR TITLE
Change: send locations option to the searchkick method

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -3,6 +3,7 @@ module Spree::ProductDecorator
     base.searchkick(
       callbacks: :async,
       word_start: [:name],
+      locations: [:location],
       settings: { number_of_replicas: 0 },
       merge_mappings: true,
       mappings: {


### PR DESCRIPTION
Sent the `locations` to the searchkick method in the `::Spree::ProductDecorator`, to allow geospatial searches. 

Docs: https://github.com/ankane/searchkick#geospatial-searches